### PR TITLE
Bug/36 fix install tango script; update to Tango 9.3.3

### DIFF
--- a/scripts/install-tango.sh
+++ b/scripts/install-tango.sh
@@ -1,49 +1,83 @@
 #!/usr/bin/env bash
+
+set -x
+set -e
+
+TANGOBOX_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
+TANGOBOX_VM_DIR="$TANGOBOX_DIR/vm"
+TANGOBOX_BUILD_DIR="$TANGOBOX_DIR/build"
+TANGOBOX_DB_DIR=~/work/tangobox/db # installed by prepare-tree.sh
+
 # specify version
-TANGO_VERSION = 9.3.2
-TANGO_RLEASE = 9.3.2-alpha.1
+TANGO_VERSION="9.3.2"
+TANGO_RELEASE="9.3.2-alpha.1"
+LOG4J_VERSION="1.2.17"
+
+sudo apt install -y \
+  libmariadb-dev \
+  libmariadbclient-dev \
+  mariadb-server
+
+sudo systemctl start mariadb
+sudo systemctl enable mariadb
 
 # install dependencies
-sudo apt-get install -y build-essential cmake autoconf libtool ant omniidl libomniorb4-dev libcos4-dev libomnithread4-dev libzmq3-dev
-sudo apt-get install openjdk-8-jre
+sudo apt install -y \
+  build-essential \
+  cmake \
+  autoconf \
+  libtool \
+  ant \
+  omniidl \
+  libomniorb4-dev \
+  libcos4-dev \
+  libomnithread4-dev \
+  libzmq3-dev
+
+sudo apt install openjdk-8-jre
 java -version
 sudo update-alternatives --config java
 java -version
 sudo apt install libmariadb-dev libmariadbclient-dev
 
 # set environment
-sudo cp ../vm/etc/profile /etc/
-sudo cp ../vm/etc/tangorc /etc/
+sudo cp -r --backup=numbered "$TANGOBOX_VM_DIR/etc"/* /etc/
+sudo cp --backup=numbered "$TANGOBOX_VM_DIR/etc/tangorc" /etc/
 
 # get, build and install tango from source distribution
-cd /home/tango-cs/work/tangobox/build
-rm -r tango-$TANGO_VERSION
-wget https://github.com/tango-controls/TangoSourceDistribution/releases/download/$TANGO_RELEASE/tango-$TANGO_RELEASE.tar.gz
-tar -zxf tango-$TANGO_RELEASE.tar.gz
+rm -rf "$TANGOBOX_BUILD_DIR"
+mkdir -p "$TANGOBOX_BUILD_DIR"
+cd "$TANGOBOX_BUILD_DIR"
+# cp ~/work/tangobox/tango-9.3.2-alpha.1.tar.gz .
+wget "https://github.com/tango-controls/TangoSourceDistribution/releases/download/$TANGO_RELEASE/tango-$TANGO_RELEASE.tar.gz"
+tar -zxf "tango-$TANGO_RELEASE.tar.gz"
+cd "$TANGOBOX_BUILD_DIR/tango-$TANGO_VERSION/"
 
-cd tango-$TANGO_VERSION
-sudo ./configure --prefix=/usr/local --without-zlib --enable-mariadb --with-mysql-admin=root --with-mariadbclient-include="/usr/include/mysql" --with-mariadbclient-lib="/usr/lib/x86_64-linux-gnu" --enable-dbcreate --enable-dbserver=yes
-sudo make
+# run configure and make with sudo to allow mysql root access
+sudo ./configure \
+  --prefix=/usr/local \
+  --without-zlib \
+  --enable-mariadb \
+  --with-mysql-admin=root \
+  --with-mariadbclient-include="/usr/include/mysql" \
+  --with-mariadbclient-lib="/usr/lib/x86_64-linux-gnu" \
+  --enable-dbcreate \
+  --enable-dbserver=yes
+sudo make -j4
 sudo make install
 sudo ldconfig
 
 # add missing log4j library
-cd /home/tango-cs/work/tangobox/build
-wget http://ftp.man.poznan.pl/apache/logging/log4j/1.2.17/log4j-1.2.17.tar.gz
-tar -xzf log4j-1.2.17.tar.gz
-sudo cp apache-log4j-1.2.17/log4j-1.2.17.jar /usr/local/share/java/
-sudo ln -s /usr/local/share/java/log4j-1.2.17.jar /usr/local/share/java/log4j.jar
-mkdir /tmp/log
-mdkir /tmp/log/TagoRestServer
+cd "$TANGOBOX_BUILD_DIR"
+wget "http://ftp.man.poznan.pl/apache/logging/log4j/$LOG4J_VERSION/log4j-$LOG4J_VERSION.tar.gz"
+tar -xzf "log4j-$LOG4J_VERSION.tar.gz"
+sudo cp "apache-log4j-$LOG4J_VERSION/log4j-$LOG4J_VERSION.jar" /usr/local/share/java/
+sudo ln -sf "/usr/local/share/java/log4j-$LOG4J_VERSION.jar" /usr/local/share/java/log4j.jar
+
+mkdir -p /tmp/log/TagoRestServer
 
 # update priviledges for database
-sudo mysql -u root -e "create user tango identified by 'tango';"
+sudo mysql -u root -e "create user if not exists tango identified by 'tango';"
 sudo mysql -u root -e "grant all on tango.* to 'tango';"
 
-cd /home/tango-cs/work/tangobox/db
-sudo mysql -u root < tango-2018-12-18-base.sql
-
-./install-services.sh
-
-. /etc/tangorc
-expor TANGO_HOST
+sudo mysql -u root --database tango < "$TANGOBOX_DB_DIR/tango-2018-12-18-base.sql"

--- a/scripts/install-tango.sh
+++ b/scripts/install-tango.sh
@@ -5,7 +5,7 @@ set -e
 
 TANGOBOX_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
 TANGOBOX_VM_DIR="$TANGOBOX_DIR/vm"
-TANGOBOX_BUILD_DIR="$TANGOBOX_DIR/build"
+TANGOBOX_BUILD_DIR=~/work/tangobox/build
 TANGOBOX_DB_DIR=~/work/tangobox/db # installed by prepare-tree.sh
 
 # specify version

--- a/scripts/install-tango.sh
+++ b/scripts/install-tango.sh
@@ -13,6 +13,8 @@ TANGO_VERSION="9.3.2"
 TANGO_RELEASE="9.3.2-alpha.1"
 LOG4J_VERSION="1.2.17"
 
+BUILD_SOURCE_DISTRIBUTION=1
+
 sudo apt install -y \
   libmariadb-dev \
   libmariadbclient-dev \
@@ -45,13 +47,22 @@ sudo cp -r --backup=numbered "$TANGOBOX_VM_DIR/etc"/* /etc/
 sudo cp --backup=numbered "$TANGOBOX_VM_DIR/etc/tangorc" /etc/
 
 # get, build and install tango from source distribution
-rm -rf "$TANGOBOX_BUILD_DIR"
+sudo rm -rf "$TANGOBOX_BUILD_DIR"
 mkdir -p "$TANGOBOX_BUILD_DIR"
 cd "$TANGOBOX_BUILD_DIR"
-# cp ~/work/tangobox/tango-9.3.2-alpha.1.tar.gz .
-wget "https://github.com/tango-controls/TangoSourceDistribution/releases/download/$TANGO_RELEASE/tango-$TANGO_RELEASE.tar.gz"
-tar -zxf "tango-$TANGO_RELEASE.tar.gz"
-cd "$TANGOBOX_BUILD_DIR/tango-$TANGO_VERSION/"
+
+if [[ $BUILD_SOURCE_DISTRIBUTION = 1 ]]; then
+  git clone --branch prepare-9.3.3 --depth 1 https://github.com/tango-controls/TangoSourceDistribution.git
+  cd TangoSourceDistribution
+  ant build package
+  cd ../
+  tar xf TangoSourceDistribution/build/tango-dev.tar.gz
+  cd tango-*/
+else
+  wget "https://github.com/tango-controls/TangoSourceDistribution/releases/download/$TANGO_RELEASE/tango-$TANGO_RELEASE.tar.gz"
+  tar -zxf "tango-$TANGO_RELEASE.tar.gz"
+  cd "$TANGOBOX_BUILD_DIR/tango-$TANGO_VERSION/"
+fi
 
 # run configure and make with sudo to allow mysql root access
 sudo ./configure \

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -25,18 +25,17 @@ sudo apt install -y \
   python-ipython \
   python-ply
 
-pip install --user \
-  numpy \
-  sphinx \
-  sphinx_rtd_theme \
-  lxml \
-  pytango \
-  fandango \
-  PyTangoArchiving \
-  itango \
-  taurus \
-  panic \
-  sardana \
+pip install --user numpy
+pip install --user sphinx
+pip install --user sphinx_rtd_theme
+pip install --user lxml
+pip install --user pytango
+pip install --user fandango
+pip install --user PyTangoArchiving
+pip install --user itango
+pip install --user taurus
+pip install --user panic
+pip install --user sardana
 
 # archiving suit from SOLEIL (java)
 mkdir -p ~/work/tangobox/build

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -1,35 +1,45 @@
 #!/usr/bin/env bash
 
-# This script installs set of  Tango tools 
+set -x
+set -e
+
+# This script installs set of  Tango tools
 
 # Python tools
-sudo apt install python-pip
-sudo apt install python-qt4
-sudo apt install qt4-designer
-sudo apt install python-qwt python-qwt5-qt4 python-guiqwt python-numpy
-sudo apt install python-pymca python-pymca5
-sudo apt install libboost-python-dev
-sudo apt install python-pyqt5.qtwebkit
-sudo apt install python-pyqt5.qtsvg
-sudo apt install python-spyder
-sudo apt install python-spyderlib
-sudo apt install python-html5lib 
-sudo apt install python-ipython
-sudo apt install python-ply
+sudo apt install -y \
+  python-pip \
+  python-qt4 \
+  qt4-designer \
+  python-qwt \
+  python-qwt5-qt4 \
+  python-guiqwt \
+  python-numpy \
+  pymca \
+  python-pymca5 \
+  libboost-python-dev \
+  python-pyqt5.qtwebkit \
+  python-pyqt5.qtsvg \
+  python-spyder \
+  python-spyderlib \
+  python-html5lib \
+  python-ipython \
+  python-ply
 
-pip install numpy --user
-pip install sphinx --user
-pip install sphinx_rtd_theme --user
-pip install lxml --user
-pip install pytango --user
-pip install fandango --user
-pip install PyTangoArchiving --user
-pip install itango --user
-pip install taurus --user
-pip install panic --user
-pip install sardana --user
+pip install --user \
+  numpy \
+  sphinx \
+  sphinx_rtd_theme \
+  lxml \
+  pytango \
+  fandango \
+  PyTangoArchiving \
+  itango \
+  taurus \
+  panic \
+  sardana \
 
 # archiving suit from SOLEIL (java)
+mkdir -p ~/work/tangobox/build
 cd ~/work/tangobox/build/
 wget -O ArchivingRoot.zip https://sourceforge.net/projects/tango-cs/files/tools/ArchivingRoot-16.2.4.zip/download
 mkdir -p ~/tools/archiving-java
@@ -55,4 +65,4 @@ wget http://ftp.esrf.eu/pub/cs/tango/hdbviewer/jython.jar
 wget -O jhdbviewer.jar https://bintray.com/tango-controls/maven/download_file?file_path=org%2Ftango%2Fjhdbviewer%2F1.14%2Fjhdbviewer-1.14.jar
 cd ../bin
 chmod +x *
-ln -s -t ~/bin ~/tools/archiving-hdbpp/bin/* 
+ln -s -t ~/bin ~/tools/archiving-hdbpp/bin/*


### PR DESCRIPTION
This PR fixes syntax issues and other errors (see #36) AND upgrades to Tango 9.3.3. Unfortunately source distribution tarball is not yet available for 9.3.3 so we have to build it manually.

@piogor please check. Also - what how do we want to handle 9.3.3? Can we leave it as it is now (i.e. build source distribution from a git checkout)? Currently we are blocked by TangoSourceDistribution release.