### PR TITLE
Use more reliable mirror for tomcat in web container

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -8,7 +8,7 @@ ENV CATALINA_HOME=/opt/tomcat
 ENV CATALINA_BASE=/opt/tomcat
 
 RUN cd /opt \
-    && wget http://ftp.man.poznan.pl/apache/tomcat/tomcat-8/v8.5.38/bin/apache-tomcat-8.5.38.tar.gz \
+    && wget http://mirror.23media.de/apache/tomcat/tomcat-8/v8.5.38/bin/apache-tomcat-8.5.38.tar.gz \
     && sudo mkdir /opt/tomcat \
     && sudo tar xzvf apache-tomcat-8*tar.gz -C /opt/tomcat --strip-components=1 \
     && rm -r apache-tomcat-8.5.38.tar.gz \


### PR DESCRIPTION
<http://ftp.man.poznan.pl/apache/tomcat/tomcat-8/v8.5.38/bin/apache-tomcat-8.5.38.tar.gz> is not accessible since v8.5.39 release.

Tomcat has a new patch release once every few weeks and `ftp.mna.poznan.pl` hosts only the latest version. 
Thus there is a high chance that one must manually change the URL in Dockerfile if one builds the vm from a scratch or uses the -lite version (which requires to build the containers before use).

I propose to switch to `mirror.23media.de` mirror as it seems that they keep old versions.