### PR TITLE
Install scripts for cumbia and qtango

### DIFF
--- a/scripts/070-install-cumbia.sh
+++ b/scripts/070-install-cumbia.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+BUILD_DIR=~/work/tangobox/build
+
+sudo apt install -y \
+  \
+  build-essential \
+  ninja-build \
+  meson \
+  git \
+  doxygen \
+  graphviz \
+  \
+  qt5-default \
+  qtcreator \
+  libqt5x11extras5-dev \
+  qttools5-dev \
+  qtscript5-dev \
+  \
+  qml-module-qtcharts \
+  qml-module-qtquick-controls2 \
+  qml-module-qtquick-dialogs \
+  qml-module-qtquick-extras \
+  qml-module-qtquick-scene2d \
+  qml-module-qtquick-scene3d \
+  qml-module-qtquick-templates2 \
+  qtdeclarative5-dev \
+  libqt5charts5-dev \
+  qtcharts5-examples \
+  qtcharts5-doc-html \
+  libqwt-qt5-dev
+
+cd "$BUILD_DIR"
+git clone --depth 1 "https://github.com/ELETTRA-SincrotroneTrieste/cumbia-libs.git"
+cd cumbia-libs
+./scripts/cubuild.sh tango install

--- a/scripts/080-install-qtango.sh
+++ b/scripts/080-install-qtango.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+BUILD_DIR=~/work/tangobox/build
+
+sudo apt install -y \
+  qt5-default \
+  libqwt-qt5-6 \
+  libqwt-qt5-dev \
+  libqt5x11extras5 \
+  libqt5x11extras5-dev \
+  libqt5designercomponents5 \
+  qttools5-dev \
+  qttools5-dev-tools \
+  libxcb-xinerama0 \
+  libqwt-dev \
+  doxygen \
+  graphviz \
+  libxmu-dev
+
+cd "$BUILD_DIR"
+git clone --depth 1 "https://github.com/ELETTRA-SincrotroneTrieste/qtango.git"
+cd qtango
+qmake
+make
+sudo make install
+
+sudo sh -c "echo '/usr/local/qtango/lib' > /etc/ld.so.conf.d/qtango.conf"
+sudo ldconfig

--- a/vm/home/tango-cs/Desktop/CumbiaClientDemo.desktop
+++ b/vm/home/tango-cs/Desktop/CumbiaClientDemo.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=false
+Icon=QtProject-qtcreator
+Exec=cumbia client sys/tg_test/1/double_scalar
+Name=CumbiaClientDemo


### PR DESCRIPTION
Fixes #42.

Some remarks:
* cumbia is still under development, it is recommended to build from git/master (see ELETTRA-SincrotroneTrieste/cumbia-libs#1)
* To build on Ubuntu 18.04 (Qt 5.9.5), ELETTRA-SincrotroneTrieste/cumbia-libs@2d8b70ee5de2b871a91097ef3c6d1c1df16cf1ab or later version is needed. There was source incompatibility fixed recently (see ELETTRA-SincrotroneTrieste/cumbia-libs#2)
* Giacomo recommends to use Qt 5.12 or better. Otherwise we may have some problems with "QtCharts" (see issue linked above). I have not investigated how much effort will be needed to upgrade 5.9.5 to 5.12.